### PR TITLE
Added searching usb0 for ip address in Pisugar-power-manager.sh

### DIFF
--- a/scripts/Pisugar-power-manager.sh
+++ b/scripts/Pisugar-power-manager.sh
@@ -59,7 +59,7 @@ done
 package_server="pisugar-server_${version}_armhf.deb"
 package_poweroff="pisugar-poweroff_${version}_armhf.deb"
 local_host="`hostname --fqdn`"
-local_ip=$(ip addr |grep inet |grep -v inet6 |grep -E "wlan0|usb0" |awk '{print $2}' |awk -F "/" '{print $1}')
+local_ip=$(ip addr |grep inet |grep -v inet6 |grep -E -m 1 "wlan0|usb0" |awk '{print $2}' |awk -F "/" '{print $1}')
 
 $echo -e "\033[1;34mDownload PiSugar-server and PiSugar-poweroff package \033[0m"
 wget -O /tmp/$package_server http://cdn.pisugar.com/${channel}/${package_server}

--- a/scripts/Pisugar-power-manager.sh
+++ b/scripts/Pisugar-power-manager.sh
@@ -59,7 +59,7 @@ done
 package_server="pisugar-server_${version}_armhf.deb"
 package_poweroff="pisugar-poweroff_${version}_armhf.deb"
 local_host="`hostname --fqdn`"
-local_ip=$(ip addr |grep inet |grep -v inet6 |grep wlan0|awk '{print $2}' |awk -F "/" '{print $1}')
+local_ip=$(ip addr |grep inet |grep -v inet6 |grep -E "wlan0|usb0" |awk '{print $2}' |awk -F "/" '{print $1}')
 
 $echo -e "\033[1;34mDownload PiSugar-server and PiSugar-poweroff package \033[0m"
 wget -O /tmp/$package_server http://cdn.pisugar.com/${channel}/${package_server}


### PR DESCRIPTION
Noticed when connected over USB for networking that the IP address wasn't showing in the install script. 
This fixes that. Only returns a max of one result.