### PR TITLE
Fix typo in link for pisugar-programmer rpm package

### DIFF
--- a/scripts/pisugar-power-manager.sh
+++ b/scripts/pisugar-power-manager.sh
@@ -119,7 +119,7 @@ else
     fi
     package_server="pisugar-server-${version}-${rpm_n}.${arch_rpm}.rpm"
     package_poweroff="pisugar-poweroff-${version}-${rpm_n}.${arch_rpm}.rpm"
-    package_programmer="pisugar-programmer_${version}-${rpm_n}.${arch_rpm}.rpm"
+    package_programmer="pisugar-programmer-${version}-${rpm_n}.${arch_rpm}.rpm"
 fi
 
 local_host="$(hostname --fqdn)"


### PR DESCRIPTION
Replaced an underscore with a dash before the `${version}` variable in the line that links to the pisugar-programmer rpm package, previously led to 404 regardless of version. Previously referenced in https://github.com/PiSugar/PiSugar/issues/130