### PR TITLE
Update install.sh - Fix install command for pisugar-programmer on aarch64 source

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -68,7 +68,7 @@ function uninstall_pisugar_poweroff() {
 
 function install_pisugar_programmer() {
     echo "Installing PiSugar Programmer..."
-    sudo install -D -m 755 target/release/pisugar-programmer /usr/bin/pisugar-programmer
+    sudo install -D -m 755 pisugar-programmer /usr/bin/pisugar-programmer
     echo "PiSugar Programmer installed."
 }
 


### PR DESCRIPTION
At least for aarch64, the pisugar-programmer binary lives in the root, not in the target folder that was listed here.  (There is no target folder.)  I don't know if this is universally true for all arch sources.